### PR TITLE
Add mark_safe to widget

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open('README.rst').read()
 
 setup(
     name="django-trix",
-    version='0.2.1',
+    version='0.2.2',
     packages=["trix"],
     include_package_data=True,
     description="Trix rich text editor widget for Django",

--- a/trix/widgets.py
+++ b/trix/widgets.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from django import forms
 from django.contrib.admin import widgets as admin_widgets
+from django.utils.safestring import mark_safe
 
 
 class TrixEditor(forms.Textarea):
@@ -19,7 +20,7 @@ class TrixEditor(forms.Textarea):
 
         html = super(TrixEditor, self).render(name, value, attrs)
         html += '<p><trix-editor {}></trix-editor></p>'.format(param_str)
-        return html
+        return mark_safe(html)
 
     class Media:
         css = {'all': ('trix/trix.css',)}


### PR DESCRIPTION
Without mark_safe, the widget rendered as an escaped string. Adding mark safe actually adds the html to the page.
